### PR TITLE
Update grunt-contrib-imagemin to ^0.9.4 

### DIFF
--- a/app/templates/client/package.json
+++ b/app/templates/client/package.json
@@ -14,7 +14,7 @@
     "grunt-contrib-copy": "^0.5.0",
     "grunt-contrib-cssmin": "^0.9.0",
     "grunt-contrib-htmlmin": "^0.3.0",
-    "grunt-contrib-imagemin": "^0.8.1",
+    "grunt-contrib-imagemin": "^0.9.4",
     "grunt-contrib-jshint": "^0.10.0",
     "grunt-contrib-uglify": "^0.4.0",
     "grunt-contrib-watch": "^0.6.1",


### PR DESCRIPTION
This can prevent possible errors on grunt build